### PR TITLE
refactor(RESTClient): improve `request` ease-of-use

### DIFF
--- a/src/RESTClient.ts
+++ b/src/RESTClient.ts
@@ -188,6 +188,7 @@ export default class RESTClient {
   }) {
     return new Promise((resolve, reject) => {
       let cancelled = false;
+      const startTime = Date.now();
       const timeout =
         init.timeout === Infinity
           ? null
@@ -289,12 +290,15 @@ export default class RESTClient {
           const queue = bucket ? bucket.queue : this.queue;
           queue.push(
             () =>
-              new Promise<void>(
-                (onResponse) =>
-                  void this.finalizeRequest(
-                    Object.assign(init, { onResponse })
-                  ).then(resolve, reject)
-              )
+              new Promise<void>((onResponse) => {
+                if (timeout !== null) clearTimeout(timeout);
+                void this.finalizeRequest(
+                  Object.assign(init, {
+                    onResponse,
+                    timeout: init.timeout - (Date.now() - startTime)
+                  })
+                ).then(resolve, reject);
+              })
           );
         }
 

--- a/src/RESTClient.ts
+++ b/src/RESTClient.ts
@@ -69,15 +69,13 @@ export default class RESTClient {
     if (bucket.flushing) return;
     bucket.flushing = true;
     try {
-      await this.block;
-
       let finalizeRequest: RequestFinalizer | null = null;
       while ((finalizeRequest = bucket.queue.shift() ?? null)) {
         /* eslint-disable no-await-in-loop */
-        if (bucket.remaining === 0) {
-          console.log('out of requests');
+        await this.block;
+
+        if (bucket.remaining === 0)
           await timers.setTimeout(bucket.reset.getTime() - Date.now());
-        }
 
         await finalizeRequest();
         /* eslint-enable no-await-in-loop */
@@ -91,13 +89,13 @@ export default class RESTClient {
     if (this.flushing) return;
     this.flushing = true;
     try {
-      await this.block;
-
       let finalizeRequest: RequestFinalizer | null = null;
       while ((finalizeRequest = this.queue.shift() ?? null)) {
-        console.log('global');
-        // eslint-disable-next-line no-await-in-loop
+        /* eslint-disable no-await-in-loop */
+        await this.block;
+
         await finalizeRequest();
+        /* eslint-enable no-await-in-loop */
       }
     } finally {
       this.flushing = false;

--- a/src/RESTClient.ts
+++ b/src/RESTClient.ts
@@ -284,6 +284,7 @@ export default class RESTClient {
           response.statusCode &&
           (response.statusCode === 429 || response.statusCode >= 500)
         ) {
+          cancelled = true;
           const bucket = init.bucketId ? this.buckets.get(init.bucketId) : null;
           const queue = bucket ? bucket.queue : this.queue;
           queue.push(

--- a/src/RESTError.ts
+++ b/src/RESTError.ts
@@ -4,13 +4,19 @@ export enum RESTErrorCode {
   /** Used when a token is requried but cannot be found */
   TOKEN_REQUIRED,
   /** Used when a request takes too long to finish and is cancelled. */
-  TIMEOUT
+  TIMEOUT,
+  /**
+   * Used when an invalid API version is provided.
+   * API versions must be a whole number greater than 0.
+   */
+  INVALID_API_VERSION
 }
 
 const messages: Record<RESTErrorCode, string> = {
   [RESTErrorCode.TOKEN_REQUIRED]:
     'A token is required to perform this operation.',
-  [RESTErrorCode.TIMEOUT]: 'The request to %s timed out after %dms.'
+  [RESTErrorCode.TIMEOUT]: 'The request to %s timed out after %dms.',
+  [RESTErrorCode.INVALID_API_VERSION]: 'An invalid API version was provided.'
 };
 
 export default class RESTError extends Error {
@@ -18,3 +24,5 @@ export default class RESTError extends Error {
     super(format(messages[code], ...args));
   }
 }
+
+export class RESTWarning extends RESTError {}

--- a/src/RESTError.ts
+++ b/src/RESTError.ts
@@ -26,3 +26,14 @@ export default class RESTError extends Error {
 }
 
 export class RESTWarning extends RESTError {}
+
+export class DiscordAPIError extends Error {
+  public constructor(
+    public readonly code: number,
+    message: string,
+    stack?: string
+  ) {
+    super(message);
+    if (stack) this.stack = `${this.name}: ${message}\n${stack}`;
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 export function captureStack(this: void) {
   const stackObject: { stack: string } = { stack: '' };
   Error.captureStackTrace(stackObject, captureStack);
-  return stackObject.stack;
+  return stackObject.stack.slice('Error\n'.length);
 }


### PR DESCRIPTION
- Removes `RequestDestination`, leaving only the `API` destination (Closes #1)
- Fixes an issue where the client spams Discord after recieving a 429 (Fixes #13)
- An error is thrown when a non-429 4xx or 5xx response is recieved (Closes #9)
- Requests are retried on a 429 response