### PR TITLE
chore: add GitHub Actions workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,4 +1,4 @@
-name: Publish package
+name: Publish development release
 
 on:
   push:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,61 @@
+name: Publish package
+
+on:
+  push:
+    branches:
+      - main
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.3
+
+      - name: Use Node.js 17
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Get hash of last commit
+        run: echo "commit_hash=$(git rev-parse --short=10 HEAD)" >> $GITHUB_ENV
+
+      - name: Modify package version
+        uses: actions/github-script@v6
+        id: package
+        with:
+          script: |
+            const { writeFile } = require('fs/promises');
+
+            const packagePath = '${{ github.workspace }}/package.json';
+
+            const package = require(packagePath);
+            package.version += '-dev.${{ env.commit_hash }}';
+
+            await writeFile(packagePath, JSON.stringify(package, null, 2));
+
+            return package.name;
+          result-encoding: string
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Deprecate previous dev release
+        run: npm deprecate '${{ steps.package.outputs.result }}@dev' || true
+        # no failing in case there isn't a previous dev release
+
+      - name: Publish dev release to npm registry
+        run: npm publish --access public --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Publish package
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.3
+
+      - name: Use Node.js 17
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Create package tarball
+        run: pnpm pack
+
+      - name: Upload release assets
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { version } = require('${{ github.workspace }}/package.json');
+            const { readFile } = require('fs/promises');
+
+            const owner = context.payload.repository.owner.login;
+            const repo = context.payload.repository.name;
+
+            const fileName = `${owner}-${repo}-${version}.tgz`;
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner,
+              repo,
+              release_id: context.payload.release.id,
+              name: fileName,
+              data: await readFile(`${{ github.workspace }}/${fileName}`)
+            });
+
+      - name: Publish to npm registry
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: Run tests
+
+on:
+  push:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['16', '17']
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run unit tests
+        run: pnpm test
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['16', '17']
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run ESLint
+        run: pnpm lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,11 +30,9 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test
+
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['16', '17']
     steps:
       - uses: actions/checkout@v2
 
@@ -42,10 +40,10 @@ jobs:
         with:
           version: 6.32.3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '17'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Adds GH Actions workflows for:

- Unit tests
- Linting
- Publishing to npm on releases
- Publishing `@dev` tag to npm on releases

Closes #18