### PR TITLE
docs: add "Small issue" template

### DIFF
--- a/.github/ISSUE_TEMPLATE/small_issue.md
+++ b/.github/ISSUE_TEMPLATE/small_issue.md
@@ -1,0 +1,26 @@
+---
+name: Small issue
+about: Report a small problem (e.g. typo)
+title: ''
+labels: bug, Needs repro
+assignees: ''
+
+---
+
+# Problem Description
+<!-- Include a clear description of the issue as well as how to reproduce it. -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help show the problem. -->
+
+## Additional information
+<!--
+Add any other context about the problem here.
+
+Move all applicable items out of the comment:
+- Operating system (Linux/macOS/Windows):
+- Package version (see `npm list`):
+- Node.js version (see `node -v`):
+- Priority this issue should have (low/med/high):
+- I have tested this issue on the latest development release.
+-->


### PR DESCRIPTION
# Describe the changes this PR makes. Why should it be merged?
This PR adds a "Small issue" issue template for small problems like typos. Closes #32.

## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on the Discord API.
- These are breaking changes (semver: major).
- These changes update the packages's interface (e.g. functions/variables added or changed)
- These changes add or modify unit tests.
-->
