### PR TITLE
docs: update template headers to use h2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-# Bug Description
+## Bug Description
 <!-- Include a clear description of the issue and the steps to reproduce it -->
 
 ## Code to reproduce

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-# What is the motivation for this feature? Describe the user story.
+## What is the motivation for this feature? Describe the user story
 <!--
 For example:
 - As a developer, I often want to [...], but I'm always frustrated when [...]
@@ -15,7 +15,7 @@ For example:
 - A useful feature to add would be [...]
 -->
 
-## Describe the solution you'd like.
+## Describe the solution you'd like
 <!-- A clear and specific description of what you want to happen. -->
 
 ### Describe the drawbacks of the solution you'd like
@@ -27,8 +27,8 @@ For example:
 - Will it make the package harder to use?
 -->
 
-## Describe alternative solutions.
+## Describe alternative solutions
 <!-- A clear and specific description of any alternative solutions or features that would solve the same problem. -->
 
-**Additional context**
+## Additional context
 <!-- Any other context, including screenshots, that could help describe your feature request -->

--- a/.github/ISSUE_TEMPLATE/small_issue.md
+++ b/.github/ISSUE_TEMPLATE/small_issue.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-# Problem Description
+## Problem Description
 <!-- Include a clear description of the issue as well as how to reproduce it. -->
 
 ## Screenshots

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Describe the changes this PR makes. Why should it be merged?
+## Describe the changes this PR makes. Why should it be merged?
 
 ## Additional Context
 <!--


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Makes template headers at most `<h2>`s because there is already an issue/pr title. Closes #34.
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on the Discord API.
- These are breaking changes (semver: major).
- These changes update the packages's interface (e.g. functions/variables added or changed)
- These changes add or modify unit tests.
-->
